### PR TITLE
NXP-29624: fix checking checkboxes when updating distribution.

### DIFF
--- a/modules/nuxeo-apidoc-core/src/main/java/org/nuxeo/apidoc/repository/RepositoryDistributionSnapshot.java
+++ b/modules/nuxeo-apidoc-core/src/main/java/org/nuxeo/apidoc/repository/RepositoryDistributionSnapshot.java
@@ -535,14 +535,16 @@ public class RepositoryDistributionSnapshot extends BaseNuxeoArtifactDocAdapter 
     public static Map<String, Serializable> getUpdateProperties(Map<String, String[]> formFields) {
         Map<String, Serializable> props = new HashMap<>();
         if (formFields != null) {
-            Stream.of(TITLE_PROPERTY_PATH, PROP_NAME, PROP_VERSION, PROP_KEY, PROP_LATEST_LTS, PROP_LATEST_FT,
-                    PROP_HIDE, PROP_RELEASED, PROP_ALIASES)
+            Stream.of(TITLE_PROPERTY_PATH, PROP_NAME, PROP_VERSION, PROP_KEY, PROP_RELEASED, PROP_ALIASES)
                   .filter(formFields::containsKey)
                   .forEach(p -> props.put(p, formFields.get(p)[0]));
             if (StringUtils.isBlank((String) props.get(TITLE_PROPERTY_PATH))
                     && StringUtils.isNotBlank((String) props.get(PROP_NAME))) {
                 props.put(TITLE_PROPERTY_PATH, props.get(PROP_NAME));
             }
+            // checkboxes will fill the request (with value "on"), only when checked
+            List.of(PROP_LATEST_LTS, PROP_LATEST_FT, PROP_HIDE)
+                .forEach(p -> props.put(p, Boolean.toString(formFields.containsKey(p))));
         }
         return props;
     }


### PR DESCRIPTION
Regression introduced by 50a7073f3ce3c10307f76d345115ca05c768d721
Unchecking the box still worked alright (as tested on ftests)