### PR TITLE
NXP-28838: remove useless table of contents on distrib index page

### DIFF
--- a/ftests/explorer-ftests-base/src/main/java/org/nuxeo/functionaltests/explorer/pages/DistributionHomePage.java
+++ b/ftests/explorer-ftests-base/src/main/java/org/nuxeo/functionaltests/explorer/pages/DistributionHomePage.java
@@ -69,10 +69,6 @@ public class DistributionHomePage extends AbstractExplorerPage {
     public WebElement packages;
 
     @Required
-    @FindBy(xpath = "//div[@id='tocDiv']")
-    public WebElement toc;
-
-    @Required
     @FindBy(xpath = "//ul[@class='exports']")
     public WebElement exports;
 
@@ -84,9 +80,6 @@ public class DistributionHomePage extends AbstractExplorerPage {
     public void check() {
         checkTitle("Nuxeo Platform Explorer");
         checkHeader(null);
-        assertEquals("Browse\n" //
-                + "Exports", //
-                toc.getText());
         // check export links presence but do not click (too costly)
         exports.findElement(By.linkText("Json Export"));
         exports.findElement(By.linkText("Json Graph"));

--- a/modules/nuxeo-apidoc-webengine/src/main/resources/skin/views/apibrowser/index.ftl
+++ b/modules/nuxeo-apidoc-webengine/src/main/resources/skin/views/apibrowser/index.ftl
@@ -1,14 +1,12 @@
 <@extends src="base.ftl">
 
 <@block name="right">
-<#include "/docMacros.ftl">
 
 <h1> Browsing Distribution '${Root.currentDistribution.key}' </h1>
 
 <div class="tabscontent">
-  <@toc />
 
-  <h2 class="toc">Browse</h2>
+  <h2>Browse</h2>
   <ul>
     <li>
       <a class="bundles" href="${Root.path}/${distId}/listBundleGroups">Bundle Groups</a>
@@ -55,7 +53,7 @@
     </#list>
   </ul>
 
-  <h2 class="toc">Exports</h2>
+  <h2>Exports</h2>
   <ul class="exports">
     <li>
       <a href="${Root.path}/${distId}/json?pretty=true">Json Export</a>
@@ -68,8 +66,6 @@
     </li>
     </#list>
   </ul>
-
-  <@tocTrigger />
 
 </div>
 


### PR DESCRIPTION
Reverting change made with 3bb41e81eeaeedda20dff206101cc282969667f4, when adding exports