### PR TITLE
NXP-29745: use the Docker image published on docker.packages.nuxeo.com

### DIFF
--- a/docker/nuxeo-explorer-export-docker/pom.xml
+++ b/docker/nuxeo-explorer-export-docker/pom.xml
@@ -68,7 +68,7 @@
               <pullNewerImage>false</pullNewerImage>
               <noCache>true</noCache>
               <buildArgs>
-                <BASE_IMAGE>docker-private.packages.nuxeo.com/nuxeo/nuxeo:${nuxeo.image.version}</BASE_IMAGE>
+                <BASE_IMAGE>docker.packages.nuxeo.com/nuxeo/nuxeo:${nuxeo.image.version}</BASE_IMAGE>
                 <BUILD_TAG>local-nuxeo-explorer-exporter</BUILD_TAG>
                 <VERSION>${nuxeo.explorer.version}-${nuxeo.image.version}</VERSION>
                 <USE_LOCAL_EXPLORER>${use.local.explorer}</USE_LOCAL_EXPLORER>


### PR DESCRIPTION
To be merged after a first successful push of the Nuxeo Docker image on docker.packages.nuxeo.com.
