### PR TITLE
NXP-29742: adapt explorer export to JSF release promotion trigger

### DIFF
--- a/ci/Jenkinsfiles/trigger-export-on-promotion.groovy
+++ b/ci/Jenkinsfiles/trigger-export-on-promotion.groovy
@@ -99,14 +99,16 @@ pipeline {
             }
             hasUpstream = true
             // parse description which should look like "Release 11.2 from build 11.2.13"
-            def matcher = (b.description =~ /Release\s(\d+\.\d+)\sfrom\sbuild\s(\d+\.\d+\.\d+).*/)
+            def matcher = (b.description =~ /Release\s(\d+\.\d+)(\sfrom\sbuild\s(\d+\.\d+\.\d+))?.*/)
             if (matcher.matches()) {
               def promotedVersion = matcher[0][1]
               echo "Parsed promoted version: ${promotedVersion}"
               jobParams.add(string(name: 'NUXEO_VERSION', value: promotedVersion))
-              def originalVersion = matcher[0][2]
-              echo "Parsed original version: ${originalVersion}"
-              jobParams.add(string(name: 'UPLOAD_ALIASES', value: originalVersion))
+              def originalVersion = matcher[0][3]
+              if (originalVersion) {
+                echo "Parsed original version: ${originalVersion}"
+                jobParams.add(string(name: 'UPLOAD_ALIASES', value: originalVersion))
+              }
 
               echo "Triggering job with parameters: ${jobParams} for ${b.absoluteUrl}"
               build job: 'export-platform-explorer-reference', parameters: jobParams, wait: false


### PR DESCRIPTION
Tested successfully at https://jenkins.platform.dev.nuxeo.com/job/nuxeo/job/nuxeo-explorer-jobs/job/trigger-export-on-promotion/15/

Actually fixed and tested again for both use cases:
https://jenkins.platform.dev.nuxeo.com/job/nuxeo/job/nuxeo-explorer-jobs/job/trigger-export-on-promotion/17/
https://jenkins.platform.dev.nuxeo.com/job/nuxeo/job/nuxeo-explorer-jobs/job/trigger-export-on-promotion/18/