### PR TITLE
NXP-29906: make upcoming explorer 20.3.0 package compliant with LTS 2021

### DIFF
--- a/packages/nuxeo-platform-explorer-package/src/main/resources/package.xml
+++ b/packages/nuxeo-platform-explorer-package/src/main/resources/package.xml
@@ -9,6 +9,7 @@
   <home-page>http://doc.nuxeo.com/x/VoVH</home-page>
   <platforms>
     <platform>server-@NUXEO_TARGET_VERSION@</platform>
+    <platform>server-2021.*</platform>
   </platforms>
   <hotreload-support>false</hotreload-support>
   <supported>true</supported>


### PR DESCRIPTION
Will release upcoming explorer version (still aligned on 11.3) as compliant with LTS, and after that, will align back on 11.4.x (and issue a maintenance branch still aligned on 11.3)