### PR TITLE
NXP-30350: cleanup files to reduce size of explorer docker images

### DIFF
--- a/docker/nuxeo-explorer-docker/Dockerfile
+++ b/docker/nuxeo-explorer-docker/Dockerfile
@@ -20,5 +20,7 @@ COPY install-packages.sh /
 COPY target/nuxeo-platform-explorer-package-*.zip /tmp/nuxeo-platform-explorer-package.zip
 RUN /install-packages.sh --offline /tmp/nuxeo-platform-explorer-package.zip >&1;
 
+# NXP-30350: remove useless files to limit docker image size
+RUN rm -rf $NUXEO_HOME/packages/backup && find $NUXEO_HOME/packages/store/* ! -name 'package.xml' -type f -exec rm -f {} +
 # Set appropriate permissions on distribution directory (moved from install-packages.sh as it takes ages)
 RUN chmod -R g+rwX $NUXEO_HOME

--- a/docker/nuxeo-explorer-export-docker/Dockerfile
+++ b/docker/nuxeo-explorer-export-docker/Dockerfile
@@ -39,6 +39,8 @@ RUN if [ ! -z "${CONNECT_EXPORT_CLID}" ] && [ ! -z "${EXPORT_PACKAGE_LIST// }" ]
 
 RUN NUXEO_CONF=$NUXEO_HOME/bin/nuxeo.conf $NUXEO_HOME/bin/nuxeoctl mp-list
 
+# NXP-30350: remove useless files to limit docker image size
+RUN rm -rf $NUXEO_HOME/packages/backup
 RUN chown -R 900:0 $NUXEO_HOME \
   && chmod -R g+rwX $NUXEO_HOME
 USER 900


### PR DESCRIPTION
To validate the optim, it would be useful to change back the 4G limit on layer push to nexus and put it back to 3G.