### PR TITLE
NXBT-3523: Fix Skaffold build - use recent API version

### DIFF
--- a/ci/Jenkinsfiles/build.groovy
+++ b/ci/Jenkinsfiles/build.groovy
@@ -251,12 +251,10 @@ pipeline {
             def moduleDir = 'docker/nuxeo-explorer-docker'
             // push images to the Jenkins X internal Docker registry
             sh "envsubst < ${moduleDir}/skaffold.yaml > ${moduleDir}/skaffold.yaml~gen"
-            retry(2) {
-              sh "skaffold build -f ${moduleDir}/skaffold.yaml~gen"
-            }
+            sh "skaffold build -f ${moduleDir}/skaffold.yaml~gen"
+            // using test in skaffold.yaml doesn't seem to work with a remote image,
+            // despite https://github.com/GoogleContainerTools/skaffold/issues/3907 supposedly solved
             sh """
-              # waiting skaffold + kaniko + container-stucture-tests issue
-              #  see https://github.com/GoogleContainerTools/skaffold/issues/3907
               docker pull ${DOCKER_REGISTRY}/nuxeo/nuxeo-explorer:${VERSION}
               container-structure-test test --image ${DOCKER_REGISTRY}/nuxeo/nuxeo-explorer:${VERSION} --config ${moduleDir}/test/*
             """

--- a/ci/Jenkinsfiles/build.groovy
+++ b/ci/Jenkinsfiles/build.groovy
@@ -32,6 +32,12 @@ void setGitHubBuildStatus(String context, String message, String state) {
   ])
 }
 
+String getCurrentNamespace() {
+  container('maven') {
+    return sh(returnStdout: true, script: "kubectl get pod ${NODE_NAME} -ojsonpath='{..namespace}'")
+  }
+}
+
 def isPullRequest() {
   return BRANCH_NAME =~ /PR-.*/
 }
@@ -93,6 +99,7 @@ pipeline {
     )
   }
   environment {
+    CURRENT_NAMESPACE = getCurrentNamespace()
     CONNECT_PROD_URL = "https://connect.nuxeo.com/nuxeo"
     MAVEN_OPTS = "$MAVEN_OPTS -Xms512m -Xmx3072m"
     MAVEN_ARGS = '-B -nsu'

--- a/ci/Jenkinsfiles/export.groovy
+++ b/ci/Jenkinsfiles/export.groovy
@@ -195,9 +195,7 @@ pipeline {
                 sh "envsubst < ${moduleDir}/skaffold.yaml > ${moduleDir}/skaffold.yaml~gen"
               }
             }
-            retry(2) {
-              sh "skaffold build -f ${moduleDir}/skaffold.yaml~gen"
-            }
+            sh "skaffold build -f ${moduleDir}/skaffold.yaml~gen"
           }
         }
       }

--- a/ci/Jenkinsfiles/export.groovy
+++ b/ci/Jenkinsfiles/export.groovy
@@ -37,6 +37,12 @@ def defaultPackages = 'cas2-authentication easyshare nuxeo-csv nuxeo-drive nuxeo
 // excluding nuxeo-spreadsheet, not released with JSF-related packages
 def additionalPackages = 'nuxeo-diff nuxeo-platform-user-registration nuxeo-virtualnavigation nuxeo-web-ui nuxeo-jsf-ui nuxeo-arender'
 
+String getCurrentNamespace() {
+  container('maven') {
+    return sh(returnStdout: true, script: "kubectl get pod ${NODE_NAME} -ojsonpath='{..namespace}'")
+  }
+}
+
 String getExportImageVersion(String explorerVersion, String nuxeoVersion) {
   def ev = explorerVersion.trim()
   def nv = nuxeoVersion.trim()
@@ -87,6 +93,8 @@ pipeline {
   }
 
   environment {
+    CURRENT_NAMESPACE = getCurrentNamespace()
+
     NUXEO_DOCKER_REGISTRY = 'docker-private.packages.nuxeo.com'
     NUXEO_IMAGE_VERSION = "${params.NUXEO_VERSION}"
     PREVIEW_NAMESPACE = "explorer-export"

--- a/ci/Jenkinsfiles/release.groovy
+++ b/ci/Jenkinsfiles/release.groovy
@@ -226,12 +226,10 @@ pipeline {
             def moduleDir="docker/nuxeo-explorer-docker"
             // push images to the Jenkins X internal Docker registry
             sh "envsubst < ${moduleDir}/skaffold.yaml > ${moduleDir}/skaffold.yaml~gen"
-            retry(2) {
-              sh "skaffold build -f ${moduleDir}/skaffold.yaml~gen"
-            }
+            sh "skaffold build -f ${moduleDir}/skaffold.yaml~gen"
+            // using test in skaffold.yaml doesn't seem to work with a remote image,
+            // despite https://github.com/GoogleContainerTools/skaffold/issues/3907 supposedly solved
             sh """
-              # waiting skaffold + kaniko + container-stucture-tests issue
-              #  see https://github.com/GoogleContainerTools/skaffold/issues/3907
               docker pull ${DOCKER_REGISTRY}/nuxeo/nuxeo-explorer:${RELEASE_VERSION}
               container-structure-test test --image ${DOCKER_REGISTRY}/nuxeo/nuxeo-explorer:${RELEASE_VERSION} --config ${moduleDir}/test/*
             """

--- a/docker/nuxeo-explorer-docker/skaffold.yaml
+++ b/docker/nuxeo-explorer-docker/skaffold.yaml
@@ -28,7 +28,7 @@ build:
         cache:
           repo: ${DOCKER_REGISTRY}/nuxeo/nuxeo-explorer/cache
   cluster:
-    namespace: platform
+    namespace: $CURRENT_NAMESPACE
     dockerConfig:
       secretName: jenkins-docker-cfg
     resources:

--- a/docker/nuxeo-explorer-docker/skaffold.yaml
+++ b/docker/nuxeo-explorer-docker/skaffold.yaml
@@ -4,16 +4,19 @@
 #     Kevin Leturc <kleturc@nuxeo.com>
 #     Anahide Tchertchian
 #
-apiVersion: skaffold/v1beta11
+apiVersion: skaffold/v2beta17
 kind: Config
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.DOCKER_REGISTRY}}/nuxeo/{{.IMAGE_NAME}}:{{.VERSION}}"
+      template: "{{.VERSION}}"
   artifacts:
-    - image: nuxeo-explorer
+    - image: "$DOCKER_REGISTRY/nuxeo/nuxeo-explorer"
       context: docker/nuxeo-explorer-docker
       kaniko:
+        useNewRun: true
+        singleSnapshot: true
+        snapshotMode: "time"
         dockerfile: Dockerfile
         buildContext:
           localDir: {}
@@ -28,10 +31,15 @@ build:
     namespace: platform
     dockerConfig:
       secretName: jenkins-docker-cfg
-# as the image is not available in docker daemon because built by kanino and thus container-structure-tests can not find it
-# furthermore, passing --pull arguments to container-structure-tests doesn't do the work as it didn't leverage docker config for auth
-# see https://github.com/GoogleContainerTools/skaffold/issues/3907
-#test:
-#  - image: nuxeo-explorer
-#    structureTests:
-#      - './docker/nuxeo-explorer-docker/test/*'
+    resources:
+      requests:
+        cpu: "1"
+        memory: "3Gi"
+      limits:
+        cpu: "2"
+        memory: "6Gi"
+    tolerations:
+      - key: team
+        operator: "Equal"
+        value: platform
+        effect: "NoSchedule"

--- a/docker/nuxeo-explorer-export-docker/skaffold.yaml
+++ b/docker/nuxeo-explorer-export-docker/skaffold.yaml
@@ -30,7 +30,7 @@ build:
           EXPORT_PACKAGE_LIST: "${EXPORT_PACKAGE_LIST}"
         # disable cache to retrieve packages again
   cluster:
-    namespace: platform
+    namespace: $CURRENT_NAMESPACE
     dockerConfig:
       secretName: jenkins-docker-cfg
     resources:

--- a/docker/nuxeo-explorer-export-docker/skaffold.yaml
+++ b/docker/nuxeo-explorer-export-docker/skaffold.yaml
@@ -4,16 +4,19 @@
 #     Kevin Leturc <kleturc@nuxeo.com>
 #     Anahide Tchertchian
 #
-apiVersion: skaffold/v1beta11
+apiVersion: skaffold/v2beta17
 kind: Config
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.DOCKER_REGISTRY}}/nuxeo/{{.IMAGE_NAME}}:{{.VERSION}}"
+      template: "{{.VERSION}}"
   artifacts:
-    - image: nuxeo-explorer-export
+    - image: "$DOCKER_REGISTRY/nuxeo/nuxeo-explorer-export"
       context: docker/nuxeo-explorer-export-docker
       kaniko:
+        useNewRun: true
+        singleSnapshot: true
+        snapshotMode: "time"
         buildArgs:
           BASE_IMAGE: ${NUXEO_DOCKER_REGISTRY}/nuxeo/nuxeo:${NUXEO_IMAGE_VERSION}
           BUILD_TAG: "{{.BUILD_TAG}}"
@@ -30,3 +33,15 @@ build:
     namespace: platform
     dockerConfig:
       secretName: jenkins-docker-cfg
+    resources:
+      requests:
+        cpu: "1"
+        memory: "3Gi"
+      limits:
+        cpu: "2"
+        memory: "6Gi"
+    tolerations:
+      - key: team
+        operator: "Equal"
+        value: platform
+        effect: "NoSchedule"


### PR DESCRIPTION
Following Skaffold uprade to 1.27.0 on base builder.

Also, fix kaniko build intermittent issue, due to a memory limitation in the kaniko pod while snapshotting the filesystem.
Solved by:
  - Setting CPU/memory resource requests/limits for the kaniko executor container.
  - Allowing to bind the kaniko pod to the Platform dedicated node pool, using tolerations.
  - Using the kaniko optimization options for filesystem snapshotting (skaffold version upgrade required).